### PR TITLE
0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,33 @@ class DropLargeColumns extends AbstractMigration
 }
 ```
 
+### Cleanup
+If there is an error while LHM is running a few triggers and tables might be left in the database.
+
+`bin/lhm` command will let you clean your database.
+
+It executes a dry-run unless the `--run` option is specified.
+
+
+```
+Large Hadron Migrator version 0.3.0
+
+Usage:
+ cleanup [-c|--configuration="..."] [-p|--parser="..."] [-e|--environment="..."] [-r|--run] [-u|--until="..."]
+
+Options:
+ --configuration (-c)  The configuration file to load
+ --parser (-p)         Parser used to read the config file. Defaults to YAML
+ --environment (-e)    The target environment
+ --run (-r)            Apply the cleanup operations.
+ --until (-u)          Drop archive tables older than the specified date at UTC (YYYY-MM-DD_hh:mm:ss).
+ --help (-h)           Display this help message
+ --quiet (-q)          Do not output any message
+
+Help:
+
+ Cleanup LHM tables, old archives and triggers. Defaults to a dry-run unless --run is specified.
+```
 
 ### AWS Considerations
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a PHP port of https://github.com/soundcloud/lhm
 
 ### TODO
 - [ ] [SqlHelper] Support column renames
-- [ ] [LHM] Support cleanup
+- [x] [LHM] Support cleanup
 - [ ] [Chunker] data limits/filtering
 - [ ] [Chunker] throttle
 - [ ] [Switchers] Locked switcher

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ class DropLargeColumns extends AbstractMigration
          * $logger = new Monolog\Logger('test', [new \Monolog\Handler\StreamHandler('php://stdout')]);
          * \Lhm\Lhm::setLogger($logger);
          */
-        \Lhm\Lhm::changeTable($this, 'characters', function (Phinx\Db\Table $table) {
+        \Lhm\Lhm::setAdapter($this->getAdapter());
+        \Lhm\Lhm::changeTable('characters', function (Phinx\Db\Table $table) {
             $table
                 ->removeColumn('alternate_name')
                 ->removeColumn('alternate_bio')
@@ -48,7 +49,8 @@ class DropLargeColumns extends AbstractMigration
      */
     public function down()
     {
-        \Lhm\Lhm::changeTable($this, 'characters', function (Phinx\Db\Table $table) {
+        \Lhm\Lhm::setAdapter($this->getAdapter());
+        \Lhm\Lhm::changeTable('characters', function (Phinx\Db\Table $table) {
             $table
                 ->addColumn('alternate_name', 'string', ['limit' => 255, 'null' => true, 'default' => null])
                 ->addColumn('alternate_bio', 'string', ['limit' => 255, 'null' => true, 'default' => null])

--- a/app/lhm.php
+++ b/app/lhm.php
@@ -1,0 +1,37 @@
+<?php
+/* Lhm
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Martin Samson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** @var callable $autoloader */
+$autoloader = require __DIR__ . '/../src/composer_autoloader.php';
+
+if (!$autoloader()) {
+    die(
+        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
+
+return new Lhm\Console\LhmApplication();

--- a/bin/lhm
+++ b/bin/lhm
@@ -1,0 +1,28 @@
+#!/usr/bin/env php
+<?php
+/* Lhm
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Martin Samson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+$app = require __DIR__ . '/../app/lhm.php';
+$app->run();

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
     "name": "masom/lhm",
+    "type": "library",
     "description": "Large Hadron Migrator for phinx",
+    "keywords": ["lhm", "phinx", "migrations", "database", "db", "database migrations"],
     "license": "MIT",
     "authors": [
         {
@@ -8,7 +10,7 @@
             "email": "martin@workshopx.com"
         }
     ],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "Lhm\\": "src/Lhm"
@@ -18,11 +20,16 @@
       "psr-4": { "Lhm\\Tests\\": "tests/" }
     },
     "require": {
-      "psr/log": "1.0.0"
+      "php": ">=5.5.0",
+      "psr/log": "1.0.0",
+      "symfony/console": "~2.6.0",
+      "symfony/event-dispatcher": "~2.6.0",
+      "symfony/monolog-bridge": "~2.6.0"
     },
     "require-dev": {
-        "monolog/monolog": "1.*",
+        "monolog/monolog": "~1.0",
         "phpunit/phpunit": "4.6.4",
-        "robmorgan/phinx": "0.4.*"
-    }
+        "robmorgan/phinx": "~0.4.0"
+    },
+    "bin": ["bin/lhm"]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,81 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9cdb5dc45d1ebed54ef816bed61a3633",
+    "hash": "0f0d984592eb4fa629108a478d6fc9cb",
     "packages": [
+        {
+            "name": "monolog/monolog",
+            "version": "1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                "reference": "c31a2c4e8db5da8b46c74cf275d7f109c0f249ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~2.4, >2.4.8",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "raven/raven": "~0.5",
+                "ruflin/elastica": "0.90.*",
+                "swiftmailer/swiftmailer": "~5.3",
+                "videlalvaro/php-amqplib": "~2.4"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "raven/raven": "Allow sending log messages to a Sentry server",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2015-03-09 09:58:04"
+        },
         {
             "name": "psr/log",
             "version": "1.0.0",
@@ -43,21 +116,197 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.6.6",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/5b91dc4ed5eb08553f57f6df04c4730a73992667",
+                "reference": "5b91dc4ed5eb08553f57f6df04c4730a73992667",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-30 15:54:10"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.6.6",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "70f7c8478739ad21e3deef0d977b38c77f1fb284"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/70f7c8478739ad21e3deef0d977b38c77f1fb284",
+                "reference": "70f7c8478739ad21e3deef0d977b38c77f1fb284",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2015-03-13 17:37:22"
+        },
+        {
+            "name": "symfony/monolog-bridge",
+            "version": "v2.6.6",
+            "target-dir": "Symfony/Bridge/Monolog",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/MonologBridge.git",
+                "reference": "b1c7af8914b8ac26abbf2e962dc315d1c54a234b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/MonologBridge/zipball/b1c7af8914b8ac26abbf2e962dc315d1c54a234b",
+                "reference": "b1c7af8914b8ac26abbf2e962dc315d1c54a234b",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "~1.11",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/console": "~2.4",
+                "symfony/event-dispatcher": "~2.2",
+                "symfony/http-kernel": "~2.4",
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "suggest": {
+                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",
+                "symfony/event-dispatcher": "Needed when using log messages in console commands",
+                "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel."
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Bridge\\Monolog\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Monolog Bridge",
+            "homepage": "http://symfony.com",
+            "time": "2015-02-24 11:52:21"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "dev-master",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "fc999e2f0508e434645ec2bfadeb89d39fa6453c"
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/fc999e2f0508e434645ec2bfadeb89d39fa6453c",
-                "reference": "fc999e2f0508e434645ec2bfadeb89d39fa6453c",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
                 "shasum": ""
             },
             "require": {
@@ -68,7 +317,7 @@
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
             },
             "type": "library",
             "extra": {
@@ -77,8 +326,8 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                "psr-0": {
+                    "Doctrine\\Instantiator\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -98,95 +347,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-04-12 20:59:10"
-        },
-        {
-            "name": "monolog/monolog",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "d84ba2cb20186688230a5a11f76a70e97fe2f886"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d84ba2cb20186688230a5a11f76a70e97fe2f886",
-                "reference": "d84ba2cb20186688230a5a11f76a70e97fe2f886",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "~2.4, >2.4.8",
-                "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "php-console/php-console": "~3.1, >3.1.2",
-                "phpunit/phpunit": "~4.0",
-                "raven/raven": "~0.5",
-                "ruflin/elastica": "0.90.*",
-                "swiftmailer/swiftmailer": "~5.3",
-                "videlalvaro/php-amqplib": "~2.4"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "raven/raven": "Allow sending log messages to a Sentry server",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.13.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "time": "2015-04-25 10:55:55"
+            "time": "2014-10-13 12:58:55"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "dev-master",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d1da796ba5565789a623052eb9f2cf59d57fec60"
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d1da796ba5565789a623052eb9f2cf59d57fec60",
-                "reference": "d1da796ba5565789a623052eb9f2cf59d57fec60",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
                 "shasum": ""
             },
             "require": {
@@ -197,8 +371,7 @@
             },
             "suggest": {
                 "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0",
-                "league/commonmark": "*"
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
@@ -223,11 +396,11 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-27 09:28:18"
+            "time": "2015-02-03 12:10:50"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "dev-master",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
@@ -287,16 +460,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "dev-master",
+            "version": "2.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "1678cee3b7f93f994da6acf7e998b23a98e955f1"
+                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/1678cee3b7f93f994da6acf7e998b23a98e955f1",
-                "reference": "1678cee3b7f93f994da6acf7e998b23a98e955f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
                 "shasum": ""
             },
             "require": {
@@ -319,7 +492,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -345,11 +518,11 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-16 05:00:01"
+            "time": "2015-04-11 04:35:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "dev-master",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
@@ -484,7 +657,7 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "dev-master",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
@@ -605,7 +778,7 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "dev-master",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
@@ -722,7 +895,7 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
@@ -786,7 +959,7 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "dev-master",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
@@ -838,7 +1011,7 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "dev-master",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
@@ -888,7 +1061,7 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
@@ -954,16 +1127,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "dev-master",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "007c441df427cf0e175372fcbb9d196bce7eb743"
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/007c441df427cf0e175372fcbb9d196bce7eb743",
-                "reference": "007c441df427cf0e175372fcbb9d196bce7eb743",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
                 "shasum": ""
             },
             "require": {
@@ -1001,11 +1174,11 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-01-20 04:09:31"
+            "time": "2014-10-06 09:23:50"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "dev-master",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
@@ -1093,17 +1266,17 @@
         },
         {
             "name": "symfony/config",
-            "version": "2.6.x-dev",
+            "version": "v2.6.6",
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "c09b78a9984f2c7fc9e3d331aa576bb25ea54052"
+                "reference": "d91be01336605db8da21b79bc771e46a7276d1bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/c09b78a9984f2c7fc9e3d331aa576bb25ea54052",
-                "reference": "c09b78a9984f2c7fc9e3d331aa576bb25ea54052",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/d91be01336605db8da21b79bc771e46a7276d1bc",
+                "reference": "d91be01336605db8da21b79bc771e46a7276d1bc",
                 "shasum": ""
             },
             "require": {
@@ -1140,36 +1313,28 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "http://symfony.com",
-            "time": "2015-04-18 15:02:51"
+            "time": "2015-03-30 15:54:10"
         },
         {
-            "name": "symfony/console",
-            "version": "2.6.x-dev",
-            "target-dir": "Symfony/Component/Console",
+            "name": "symfony/filesystem",
+            "version": "v2.6.6",
+            "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
-                "reference": "d46ae15633480fe35c6be26f1ee97ec02ab9eba4"
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "4983964b3693e4f13449cb3800c64a9112c301b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d46ae15633480fe35c6be26f1ee97ec02ab9eba4",
-                "reference": "d46ae15633480fe35c6be26f1ee97ec02ab9eba4",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/4983964b3693e4f13449cb3800c64a9112c301b4",
+                "reference": "4983964b3693e4f13449cb3800c64a9112c301b4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/process": ""
+                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
@@ -1179,55 +1344,6 @@
             },
             "autoload": {
                 "psr-0": {
-                    "Symfony\\Component\\Console\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-18 15:02:51"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "2.8.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "41b7d35d812653a54fd931a6c8cf139767a95abb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/41b7d35d812653a54fd931a6c8cf139767a95abb",
-                "reference": "41b7d35d812653a54fd931a6c8cf139767a95abb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
                 }
             },
@@ -1247,21 +1363,21 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "http://symfony.com",
-            "time": "2015-04-24 07:03:44"
+            "time": "2015-03-22 16:55:57"
         },
         {
             "name": "symfony/yaml",
-            "version": "2.6.x-dev",
+            "version": "v2.6.6",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "7e9e156003c943f0023378691ee5b8366b77deda"
+                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/7e9e156003c943f0023378691ee5b8366b77deda",
-                "reference": "7e9e156003c943f0023378691ee5b8366b77deda",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/174f009ed36379a801109955fc5a71a49fe62dd4",
+                "reference": "174f009ed36379a801109955fc5a71a49fe62dd4",
                 "shasum": ""
             },
             "require": {
@@ -1297,13 +1413,15 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2015-04-18 15:02:51"
+            "time": "2015-03-30 15:54:10"
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.5.0"
+    },
     "platform-dev": []
 }

--- a/src/Lhm/AtomicSwitcher.php
+++ b/src/Lhm/AtomicSwitcher.php
@@ -42,7 +42,7 @@ class AtomicSwitcher extends Command
         $this->options = $options + [
                 'retry_sleep_time' => 10,
                 'max_retries' => 600,
-                'archive_name' => "{$origin->getName()}_" . gmdate('Y_m_d_H_i_s')
+                'archive_name' => 'lhma_' . gmdate('Y_m_d_H_i_s') . "_{$origin->getName()}"
             ];
 
         $this->adapter = $adapter;

--- a/src/Lhm/Chunker.php
+++ b/src/Lhm/Chunker.php
@@ -57,7 +57,7 @@ class Chunker extends Command
         $this->destination = $destination;
         $this->sqlHelper = $sqlHelper ?: new SqlHelper($this->adapter);
 
-        $this->options = $options + ['stride' => 500];
+        $this->options = $options + ['stride' => 2000];
 
         $this->primaryKey = $this->adapter->quoteColumnName($this->sqlHelper->extractPrimaryKey($this->origin));
 

--- a/src/Lhm/Console/Command/Cleanup.php
+++ b/src/Lhm/Console/Command/Cleanup.php
@@ -1,0 +1,112 @@
+<?php
+
+
+namespace Lhm\Console\Command;
+
+
+use Lhm\Lhm;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Phinx\Console\Command\AbstractCommand;
+use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cleanup extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('cleanup')
+            ->setDescription('Cleanup LHM tables, old archives and triggers')
+            ->setHelp(sprintf(
+                '%sCleanup LHM tables, old archives and triggers. Defaults to a dry-run unless --run is specified.%s',
+                PHP_EOL,
+                PHP_EOL
+            ));
+
+        $this->addOption('--environment', '-e', InputOption::VALUE_REQUIRED, 'The target environment');
+
+        // Apply operations
+        $this->addOption('--run', 'r', InputOption::VALUE_NONE, 'Apply the cleanup operations.');
+
+        // Archives older than the specified UTC date + time will be dropped.
+        $this->addOption('--until', 'u', InputOption::VALUE_REQUIRED, 'Drop archive tables older than the specified date at UTC (YYYY-MM-DD_hh:mm:ss).');
+    }
+
+    /**
+     * Cleanup the database
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$this->getConfig()) {
+            $this->loadConfig($input, $output);
+        }
+
+        $this->loadManager($output);
+
+        $environment = $input->getOption('environment');
+
+        if (null === $environment) {
+            $environment = $this->getConfig()->getDefaultEnvironment();
+            $output->writeln('<comment>warning</comment> no environment specified, defaulting to: ' . $environment);
+        } else {
+            $output->writeln('<info>using environment</info> ' . $environment);
+        }
+
+        $envOptions = $this->getConfig()->getEnvironment($environment);
+        if (isset($envOptions['adapter'])) {
+            $output->writeln('<info>using adapter</info> ' . $envOptions['adapter']);
+        }
+
+        if (isset($envOptions['name'])) {
+            $output->writeln('<info>using database</info> ' . $envOptions['name']);
+        }
+
+        $run = (bool)$input->getOption('run');
+        $until = $input->getOption('until');
+
+        if ($until) {
+            $until = \DateTime::createFromFormat('Y-M-D_H:i:s', $until, new \DateTimeZone('UTC'));
+
+            if ($until === false) {
+                throw new \InvalidArgumentException("The specified date in `until` is invalid.");
+            }
+        }
+
+
+        if ($run) {
+            $output->writeln('<info>LHM will drop temporary tables and triggers</info>');
+        } else {
+            $output->writeln('<info>Executing dry-run</info>');
+        }
+
+        $options = [];
+        if ($until) {
+            $options['until'] = $until;
+            $output->writeln('<warning>LHM will drop archives created before ' . $until->format('Y-M-D H:i:s T') . '</warning>');
+        }
+
+        if (!$input->getOption('quiet')) {
+            $logger = new Logger('lhm');
+            $logger->pushHandler(new ConsoleHandler($output));
+            Lhm::setLogger($logger);
+        }
+
+        $environment = $this->manager->getEnvironment($environment);
+
+        Lhm::setAdapter($environment->getAdapter());
+        Lhm::cleanup($run, $options);
+    }
+}

--- a/src/Lhm/Console/Command/Cleanup.php
+++ b/src/Lhm/Console/Command/Cleanup.php
@@ -98,11 +98,14 @@ class Cleanup extends AbstractCommand
             $output->writeln('<warning>LHM will drop archives created before ' . $until->format('Y-M-D H:i:s T') . '</warning>');
         }
 
-        if (!$input->getOption('quiet')) {
-            $logger = new Logger('lhm');
-            $logger->pushHandler(new ConsoleHandler($output));
-            Lhm::setLogger($logger);
-        }
+
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $handler = new ConsoleHandler($output);
+
+        $logger = new Logger('lhm');
+        $logger->pushHandler($handler);
+
+        Lhm::setLogger($logger);
 
         $environment = $this->manager->getEnvironment($environment);
 

--- a/src/Lhm/Console/LhmApplication.php
+++ b/src/Lhm/Console/LhmApplication.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Lhm\Console;
+
+use Symfony\Component\Console\Application;
+
+
+class LhmApplication extends Application
+{
+    /**
+     * Class Constructor.
+     *
+     * Initialize the Lhm console application.
+     *
+     * @param string $version The Application Version
+     */
+    public function __construct($version = '0.3.0')
+    {
+        parent::__construct('Large Hadron Migrator', $version);
+
+        $this->addCommands([
+            new Command\Cleanup()
+        ]);
+    }
+}

--- a/src/Lhm/Lhm.php
+++ b/src/Lhm/Lhm.php
@@ -4,6 +4,8 @@
 namespace Lhm;
 
 
+use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Table;
 use Phinx\Migration\MigrationInterface;
 use Psr\Log\LoggerInterface;
 
@@ -11,6 +13,11 @@ class Lhm
 {
     /** @var LoggerInterface */
     protected static $logger;
+
+    /**
+     * @var AdapterInterface
+     */
+    protected static $adapter;
 
     public static function setLogger(LoggerInterface $logger)
     {
@@ -25,10 +32,122 @@ class Lhm
         return static::$logger ?: new NullLogger();
     }
 
-    public static function changeTable(MigrationInterface $migration, $name, callable $operations, array $options = [])
+    /**
+     * @return AdapterInterface
+     */
+    public static function getAdapter()
     {
-        $invoker = new Invoker($migration, $migration->table($name, []), $options);
+        return self::$adapter;
+    }
+
+    /**
+     * @param AdapterInterface $adapter
+     */
+    public static function setAdapter(AdapterInterface $adapter)
+    {
+        self::$adapter = $adapter;
+    }
+
+    /**
+     * @param $name
+     * @param callable $operations
+     * @param array $options
+     */
+    public static function changeTable($name, callable $operations, array $options = [])
+    {
+        if (!static::getAdapter()) {
+            throw new \RuntimeException(__CLASS__ . ' must have an adapter set. Call ' . __CLASS__ . '::setAdapter()');
+        }
+
+        $invoker = new Invoker(static::$adapter, new Table($name, [], static::getAdapter()), $options);
         $invoker->setLogger(static::getLogger());
         $invoker->execute($operations);
+    }
+
+    /**
+     * @param bool $run
+     * @param array $options
+     */
+    public static function cleanup($run = false, array $options = [])
+    {
+        if (!static::getAdapter()) {
+            throw new \RuntimeException(__CLASS__ . ' must have an adapter. Call ' . __CLASS__ . '::setAdapter()');
+        }
+
+        $logger = static::getLogger();
+
+        $options += ['until' => false];
+
+        if ($options['until'] && !($options['until'] instanceof \DateTime)) {
+            throw new \UnexpectedValueException('The `until` option must be an instance of \DateTime');
+        }
+
+        /** @var \PDOStatement $statement */
+        $statement = static::getAdapter()->query('show tables');
+
+        $lhmTables = [];
+        while (($table = $statement->fetchColumn(0)) !== false) {
+            if (!preg_match('/^lhm(a|n)_/', $table)) {
+                continue;
+            }
+            $lhmTables[] = $table;
+        }
+
+        $tablesToClean = [];
+        if ($options['until']) {
+            foreach ($lhmTables as $table) {
+                if (!preg_match("/^lhma_([0-9]{4}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2})_/", $table, $matches)) {
+                    continue;
+                }
+
+                $dateTime = \DateTime::createFromFormat('Y_m_d_H_i_s', $matches[1], new \DateTimeZone("UTC"));
+
+                if ($dateTime <= $options['until']) {
+                    $tablesToClean[] = $table;
+                }
+            }
+            unset($table);
+        }
+
+        $lhmTables = $tablesToClean;
+
+        $lhmTriggers = [];
+        /** @var \PDOStatement $statement */
+        $statement = static::getAdapter()->query('show triggers');
+        while (($trigger = $statement->fetchColumn(0)) !== false) {
+            if (!preg_match('/^lhmt/', $trigger)) {
+                continue;
+            }
+            $lhmTriggers[] = $trigger;
+        }
+        unset($trigger);
+
+        if ($run) {
+            $adapter = static::$adapter;
+
+            foreach ($lhmTriggers as $trigger) {
+                $logger->info("Dropping trigger `{$trigger}`");
+                $adapter->query("DROP TRIGGER IF EXISTS {$trigger}");
+            }
+
+            foreach ($lhmTables as $table) {
+                $logger->info("Dropping table `{$table}`");
+
+                $table = $adapter->quoteTableName($table);
+                $adapter->query("DROP TABLE IF EXISTS {$table}");
+            }
+
+            return true;
+        } elseif (empty($lhmTables) && empty($lhmTriggers)) {
+            $logger->info("Everything is clean. Nothing to do.");
+            return true;
+        } else {
+            $tables = implode(", ", $lhmTables);
+            $triggers = implode(", ", $lhmTriggers);
+            $logger->info("Existing LHM backup tables: {$tables}.");
+            $logger->info("Existing LHM triggers: {$triggers}.");
+            $logger->info('Run Lhm::cleanup(true) to drop them all.');
+            return false;
+        }
     }
 }

--- a/src/Lhm/Lhm.php
+++ b/src/Lhm/Lhm.php
@@ -6,7 +6,6 @@ namespace Lhm;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
-use Phinx\Migration\MigrationInterface;
 use Psr\Log\LoggerInterface;
 
 class Lhm
@@ -19,6 +18,9 @@ class Lhm
      */
     protected static $adapter;
 
+    /**
+     * @param LoggerInterface $logger
+     */
     public static function setLogger(LoggerInterface $logger)
     {
         static::$logger = $logger;
@@ -65,8 +67,13 @@ class Lhm
     }
 
     /**
-     * @param bool $run
+     * Cleanup LHM temporary tables, old archives and triggers.
+     *
+     * @param bool $run When set to `false` the cleanup operations will not be executed. ( dry-run )
      * @param array $options
+     *                      - `until` \DateTime Archives older than this date will be deleted.
+     *
+     * @return bool
      */
     public static function cleanup($run = false, array $options = [])
     {

--- a/src/Lhm/Lhm.php
+++ b/src/Lhm/Lhm.php
@@ -129,6 +129,11 @@ class Lhm
         }
         unset($trigger);
 
+        if (empty($lhmTables) && empty($lhmTriggers)) {
+            $logger->info("Everything is clean. Nothing to do.");
+            return true;
+        }
+
         if ($run) {
             $adapter = static::$adapter;
 
@@ -145,14 +150,11 @@ class Lhm
             }
 
             return true;
-        } elseif (empty($lhmTables) && empty($lhmTriggers)) {
-            $logger->info("Everything is clean. Nothing to do.");
-            return true;
         } else {
             $tables = implode(", ", $lhmTables);
             $triggers = implode(", ", $lhmTriggers);
-            $logger->info("Existing LHM backup tables: {$tables}.");
-            $logger->info("Existing LHM triggers: {$triggers}.");
+            $logger->info("Existing LHM backup tables: {$tables}");
+            $logger->info("Existing LHM triggers: {$triggers}");
             $logger->info('Run Lhm::cleanup(true) to drop them all.');
             return false;
         }

--- a/src/composer_autoloader.php
+++ b/src/composer_autoloader.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Phinx
+ *
+ * (The MIT license)
+ * Copyright (c) 2015 Rob Morgan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated * documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+
+/**
+ * Attempts to load Composer's autoload.php as either a dependency or a
+ * stand-alone package.
+ *
+ * @return boolean
+ */
+return function () {
+    $files = array(
+        __DIR__ . '/../../../autoload.php',  // composer dependency
+        __DIR__ . '/../vendor/autoload.php', // stand-alone package
+    );
+    foreach ($files as $file) {
+        if (is_file($file)) {
+            require_once $file;
+            return true;
+        }
+    }
+    return false;
+};

--- a/tests/Persistence/AtomicSwitcherTest.php
+++ b/tests/Persistence/AtomicSwitcherTest.php
@@ -40,7 +40,7 @@ class AtomicSwitcherTest extends AbstractPersistenceTest
         $migration->setAdapter($this->adapter);
         $migration->up();
 
-        $invoker = new Invoker($migration, $this->origin);
+        $invoker = new Invoker($this->adapter, $this->origin);
 
         $this->destination = $invoker->temporaryTable();
         $this->switcher = new AtomicSwitcher($this->adapter, $this->origin, $this->destination);

--- a/tests/Persistence/LhmTest.php
+++ b/tests/Persistence/LhmTest.php
@@ -67,17 +67,50 @@ class LhmTest extends AbstractPersistenceTest
 
     public function testCleanup()
     {
-        $this->adapter->query('CREATE TABLE derp(id INT PRIMARY KEY);');
-        $this->adapter->query('CREATE TABLE lhma_2014_03_04_13_22_33_test(id INT PRIMARY KEY);');
+        $this->adapter->query('CREATE TABLE test(id INT PRIMARY KEY);');
+        $this->adapter->query('CREATE TABLE lhma_2015_03_04_13_22_33_test(id INT PRIMARY KEY);');
         $this->adapter->query(implode("\n ", [
-            'CREATE TRIGGER lhmt_update_users',
-            'AFTER UPDATE ON derp FOR EACH ROW',
+            'CREATE TRIGGER lhmt_update_test',
+            'AFTER UPDATE ON test FOR EACH ROW',
             'REPLACE INTO derp (`id`) /* large hadron migration (php) */',
             'VALUES (NEW.`id`)'
         ]));
 
-        Lhm::setLogger(new \Monolog\Logger('test', [new \Monolog\Handler\StreamHandler('php://stdout')]));
         Lhm::setAdapter($this->adapter);
-        Lhm::cleanup(true);
+        Lhm::cleanup(true, ['until' => new \DateTime()]);
+
+        /** @var \PDOStatement $statement */
+        $statement = $this->adapter->query('show triggers');
+        $this->assertEquals(false, $statement->fetchColumn(0));
+
+        $statement = $this->adapter->query('show tables');
+        $this->assertEquals(2, $statement->rowCount());
+        $this->assertEquals('phinxlog', $statement->fetchColumn(0));
+        $this->assertEquals('test', $statement->fetchColumn(0));
+    }
+
+    public function testCleanupDryRun()
+    {
+        $this->adapter->query('CREATE TABLE test(id INT PRIMARY KEY);');
+        $this->adapter->query('CREATE TABLE lhma_2015_03_04_13_22_33_test(id INT PRIMARY KEY);');
+        $this->adapter->query(implode("\n ", [
+            'CREATE TRIGGER lhmt_update_test',
+            'AFTER UPDATE ON test FOR EACH ROW',
+            'REPLACE INTO derp (`id`) /* large hadron migration (php) */',
+            'VALUES (NEW.`id`)'
+        ]));
+
+        Lhm::setAdapter($this->adapter);
+        Lhm::cleanup(false, ['until' => new \DateTime()]);
+
+        /** @var \PDOStatement $statement */
+        $statement = $this->adapter->query('show triggers');
+        $this->assertEquals('lhmt_update_test', $statement->fetchColumn(0));
+
+        $statement = $this->adapter->query('show tables');
+        $this->assertEquals(3, $statement->rowCount());
+        $this->assertEquals('lhma_2015_03_04_13_22_33_test', $statement->fetchColumn(0));
+        $this->assertEquals('phinxlog', $statement->fetchColumn(0));
+        $this->assertEquals('test', $statement->fetchColumn(0));
     }
 }

--- a/tests/Persistence/LhmTest.php
+++ b/tests/Persistence/LhmTest.php
@@ -64,4 +64,20 @@ class LhmTest extends AbstractPersistenceTest
         $this->assertEquals(null, $age);
         $this->assertEquals('Canada', $location);
     }
+
+    public function testCleanup()
+    {
+        $this->adapter->query('CREATE TABLE derp(id INT PRIMARY KEY);');
+        $this->adapter->query('CREATE TABLE lhma_2014_03_04_13_22_33_test(id INT PRIMARY KEY);');
+        $this->adapter->query(implode("\n ", [
+            'CREATE TRIGGER lhmt_update_users',
+            'AFTER UPDATE ON derp FOR EACH ROW',
+            'REPLACE INTO derp (`id`) /* large hadron migration (php) */',
+            'VALUES (NEW.`id`)'
+        ]));
+
+        Lhm::setLogger(new \Monolog\Logger('test', [new \Monolog\Handler\StreamHandler('php://stdout')]));
+        Lhm::setAdapter($this->adapter);
+        Lhm::cleanup(true);
+    }
 }

--- a/tests/Persistence/Migrations/HybridPhinxMigration.php
+++ b/tests/Persistence/Migrations/HybridPhinxMigration.php
@@ -17,7 +17,8 @@ class HybridPhinxMigration extends AbstractMigration
             ->addColumn('location', 'string', ['null' => true, 'length' => 255, 'default' => 'Canada'])
             ->save();
 
-        Lhm::changeTable($this, 'ponies', function (Table $ponies) {
+        Lhm::setAdapter($this->getAdapter());
+        Lhm::changeTable('ponies', function (Table $ponies) {
             $ponies
                 ->addColumn('age', 'integer', ['null' => true])
                 ->save();

--- a/tests/Persistence/Migrations/LhmMigration.php
+++ b/tests/Persistence/Migrations/LhmMigration.php
@@ -11,7 +11,8 @@ class LhmMigration extends AbstractMigration
 {
     public function up()
     {
-        Lhm::changeTable($this, 'ponies', function (Table $ponies) {
+        Lhm::setAdapter($this->getAdapter());
+        Lhm::changeTable('ponies', function (Table $ponies) {
             $ponies->addColumn('age', 'integer', ['default' => 1]);
             $ponies->addColumn('nickname', 'string', ['after' => 'name', 'length' => 20, 'null' => true, 'default' => 'derp']);
             $ponies->save();


### PR DESCRIPTION
### New features
- `\Lhm\Lhm::cleanup($run, $options)` and `bin\lhm`
### Breaking Changes

This commit introduces a breaking change on the LHM API.

LHM should now be configured with `\Lhm\Lhm::setAdapter(AdapterInterface $adapter)` instead of passing a `MigrationInterface` instance to `\Lhm\Lhm::changeTable`.

before

``` php
\Lhm\Lhm::changeTable($this, $name, function(){}, $options);
```

after:

``` php
\Lhm\Lhm::setAdapter($this->getAdapter());
\Lhm\Lhm::changeTable($name, function(){}, $options);
```
