### PR TITLE
0.3.3

### DIFF
--- a/src/Lhm/Chunker.php
+++ b/src/Lhm/Chunker.php
@@ -49,6 +49,9 @@ class Chunker extends Command
      * @param Table $origin
      * @param Table $destination
      * @param SqlHelper $sqlHelper
+     * @param array $options
+     *                      - `stride`
+     *                          Size of chunk ( defaults to 2000 )
      */
     public function __construct(AdapterInterface $adapter, Table $origin, Table $destination, SqlHelper $sqlHelper = null, array $options = [])
     {

--- a/src/Lhm/Lhm.php
+++ b/src/Lhm/Lhm.php
@@ -54,6 +54,17 @@ class Lhm
      * @param $name
      * @param callable $operations
      * @param array $options
+     *                      - `stride` integer
+     *                          Size of a chunk (defaults to 2000)
+     *                      - `atomic_switch` boolean
+     *                          Enable atomic switching (defaults to true)
+     *                      - `retry_sleep_time` integer
+     *                          How long should the switch wait until retrying ( defaults to 10 )
+     *                      - `max_retries` integer
+     *                          How many times the switch should be attempted ( defaults to 600 )
+     *                      - `archive_name` string
+     *                          Name of the archive table ( defaults to 'lhma_' . gmdate('Y_m_d_H_i_s') . "_{$origin->getName()}" )
+     *
      */
     public static function changeTable($name, callable $operations, array $options = [])
     {

--- a/src/Lhm/LockedSwitcher.php
+++ b/src/Lhm/LockedSwitcher.php
@@ -65,11 +65,17 @@ class LockedSwitcher extends Command
     /**
      * @return array
      */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return array
+     */
     protected function statements()
     {
-        return $this->uncommitted(function () {
-            $this->switchStatements();
-        });
+        return $this->uncommitted($this->switchStatements());
     }
 
     /**
@@ -92,17 +98,17 @@ class LockedSwitcher extends Command
     }
 
     /**
-     * @param callable $wrapped
+     * @param array $switchStatements
      * @return array
      */
-    protected function uncommitted(callable $wrapped)
+    protected function uncommitted($switchStatements)
     {
         $statements = [
             'set @lhm_auto_commit = @@session.autocommit',
             'set session autocommit = 0'
         ];
 
-        $statements = array_merge($statements, $wrapped());
+        $statements = array_merge($statements, $switchStatements);
 
         $statements[] = 'set session autocommit = @lhm_auto_commit';
         return $statements;

--- a/src/Lhm/SqlHelper.php
+++ b/src/Lhm/SqlHelper.php
@@ -42,9 +42,10 @@ class SqlHelper
      */
     public function versionString()
     {
+        /** @var \PDOStatement $data */
         $data = $this->adapter->query("show variables like 'version'");
 
-        return $data[0];
+        return $data->fetchColumn(1);
     }
 
     /**

--- a/tests/Integration/AtomicSwitcherTest.php
+++ b/tests/Integration/AtomicSwitcherTest.php
@@ -68,9 +68,16 @@ class AtomicSwitcherTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValueMap([['users', true], ['users_new', true]]));
 
         $this->adapter
+            ->expects($this->atLeastOnce())
+            ->method('quoteTableName')
+            ->will($this->returnCallback(function ($name) {
+                return "`{$name}`";
+            }));
+
+        $this->adapter
             ->expects($this->once())
             ->method('query')
-            ->with('RENAME TABLE users TO users_archive, users_new TO users');
+            ->with('RENAME TABLE `users` TO `users_archive`, `users_new` TO `users`');
 
         $this->origin
             ->expects($this->atLeastOnce())

--- a/tests/Integration/LockedSwitcherTest.php
+++ b/tests/Integration/LockedSwitcherTest.php
@@ -1,0 +1,94 @@
+<?php
+
+
+namespace Lhm\Tests\Integration;
+
+
+use Lhm\AtomicSwitcher;
+use Phinx\Db\Adapter\AdapterInterface;
+use Phinx\Db\Table;
+
+class AtomicSwitcherTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var AtomicSwitcher
+     */
+    protected $switcher;
+    /**
+     * @var AdapterInterface
+     */
+    protected $adapter;
+    /**
+     * @var Table
+     */
+    protected $origin;
+    /**
+     * @var Table
+     */
+    protected $destination;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->adapter = $this->getMockBuilder(AdapterInterface::class)->getMock();
+        $this->adapter
+            ->expects($this->any())
+            ->method('quoteColumnName')
+            ->will($this->returnCallback(function ($name) {
+                return "`{$name}`";
+            }));
+
+        $this->origin = $this->getMockBuilder(Table::class)->disableOriginalConstructor()->getMock();
+        $this->destination = $this->getMockBuilder(Table::class)->disableOriginalConstructor()->getMock();
+
+        $this->switcher = new AtomicSwitcher(
+            $this->adapter,
+            $this->origin,
+            $this->destination,
+            [
+                'archive_name' => 'users_archive'
+            ]
+        );
+    }
+
+    protected function tearDown()
+    {
+        unset($this->switcher, $this->adapter, $this->origin, $this->destination);
+        parent::tearDown();
+    }
+
+
+    public function test()
+    {
+
+        $this->adapter
+            ->expects($this->atLeastOnce())
+            ->method('hasTable')
+            ->will($this->returnValueMap([['users', true], ['users_new', true]]));
+
+        $this->adapter
+            ->expects($this->atLeastOnce())
+            ->method('quoteTableName')
+            ->will($this->returnCallback(function ($name) {
+                return "`{$name}`";
+            }));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('query')
+            ->with('RENAME TABLE `users` TO `users_archive`, `users_new` TO `users`');
+
+        $this->origin
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->will($this->returnValue('users'));
+
+        $this->destination
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->will($this->returnValue('users_new'));
+
+        $this->switcher->run();
+    }
+}

--- a/tests/Integration/SqlHelperTest.php
+++ b/tests/Integration/SqlHelperTest.php
@@ -156,7 +156,16 @@ class SqlHelperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function () use ($matcherIterator) {
                 $value = $matcherIterator->current();
                 $matcherIterator->next();
-                return [$value];
+
+                $mock = $this->getMockBuilder(\stdClass::class)
+                    ->setMethods(['fetchColumn'])
+                    ->disableOriginalConstructor()
+                    ->getMock();
+
+                $mock->expects($this->once())
+                    ->method('fetchColumn')
+                    ->will($this->returnValue($value));
+                return $mock;
             }));
 
         foreach ($expectedIterator as $version => $expected) {
@@ -166,11 +175,19 @@ class SqlHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testVersionString()
     {
+        $mock = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['fetchColumn'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('fetchColumn')
+            ->will($this->returnValue("3.0.2"));
+
         $this->adapter
             ->expects($this->once())
             ->method('query')
             ->with("show variables like 'version'")
-            ->will($this->returnValue(["3.0.2"]));
+            ->will($this->returnValue($mock));
 
         $this->assertEquals("3.0.2", $this->helper->versionString());
     }

--- a/tests/Persistence/LockedSwitcherTest.php
+++ b/tests/Persistence/LockedSwitcherTest.php
@@ -1,0 +1,88 @@
+<?php
+
+
+namespace tests\Persistence;
+
+
+use Lhm\LockedSwitcher;
+use Lhm\Invoker;
+use Lhm\Tests\Persistence\Migrations\InitialMigration;
+use Phinx\Db\Table;
+
+/**
+ * @see https://github.com/soundcloud/lhm/blob/b8819c550b1b471b563036276bbfffe5c990777d/lib/lhm/locked_switcher.rb#L9
+ *
+ * Switches origin with destination table nonatomically using a locked write.
+ * LockedSwitcher adopts the Facebook strategy, with the following caveat:
+ *
+ * "Since alter table causes an implicit commit in innodb, innodb locks get
+ * released after the first alter table. So any transaction that sneaks in
+ * after the first alter table and before the second alter table gets
+ * a 'table not found' error. The second alter table is expected to be very
+ * fast though because copytable is not visible to other transactions and so
+ * there is no need to wait."
+
+ */
+class LockedSwitcherTest extends AbstractPersistenceTest
+{
+
+    /**
+     * @var LockedSwitcher
+     */
+    protected $switcher;
+
+    /**
+     * @var Table
+     */
+    protected $origin;
+    /**
+     * @var Table
+     */
+    protected $destination;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->adapter->execute("SET GLOBAL innodb_lock_wait_timeout=3");
+        $this->adapter->execute("SET GLOBAL lock_wait_timeout=3");
+
+        $this->origin = new Table('ponies');
+
+
+        $migration = new InitialMigration(time());
+        $migration->setAdapter($this->adapter);
+        $migration->up();
+
+        $invoker = new Invoker($this->adapter, $this->origin);
+
+        $this->destination = $invoker->temporaryTable();
+        $this->switcher = new LockedSwitcher($this->adapter, $this->origin, $this->destination);
+    }
+
+    public function testRetryOnLockTimeouts()
+    {
+        $this->markTestSkipped('Requires implementation of https://github.com/soundcloud/lhm/blob/b8819c550b1b471b563036276bbfffe5c990777d/spec/integration/integration_helper.rb#L91');
+        //$this->switcher->setOption('retry_sleep_time', 0.3);
+        //$this->switcher->run();
+    }
+
+    public function testItRenamesOriginToArchive()
+    {
+        $archive = $this->switcher->getOptions()['archive_name'];
+        $this->assertFalse($this->adapter->hasTable($archive));
+
+        $this->switcher->run();
+
+        $this->assertTrue($this->adapter->hasTable($archive));
+    }
+
+    public function testItRenamesDestinationToOrigin()
+    {
+        $this->assertTrue($this->adapter->hasTable($this->destination->getName()));
+
+        $this->switcher->run();
+
+        $this->assertFalse($this->adapter->hasTable($this->destination->getName()));
+    }
+}


### PR DESCRIPTION
- `LockedSwitcher` implemented.
- `Lhm\Lhm::changeTable($name, function(Table $table){}, $options)` now takes the options to force `atomic_switch`.

Fixed `SqlHelper::versionString()`
