### PR TITLE
Changed dependencies for symfony to major version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require": {
       "php": ">=5.5.0",
       "psr/log": "1.0.0",
-      "symfony/console": "~2.6.0",
-      "symfony/event-dispatcher": "~2.6.0",
-      "symfony/monolog-bridge": "~2.6.0"
+      "symfony/console": "~2",
+      "symfony/event-dispatcher": "~2",
+      "symfony/monolog-bridge": "~2"
     },
     "require-dev": {
         "monolog/monolog": "~1.0",


### PR DESCRIPTION
The current dep doesn't resolve correctly with Phinx. I think it's pretty safe to use the major version instead of the minor.

All of the tests passed :+1:.
