### PR TITLE
Fix Chunker when primary key is not "id"

### DIFF
--- a/src/Lhm/Chunker.php
+++ b/src/Lhm/Chunker.php
@@ -106,7 +106,7 @@ class Chunker extends Command
     protected function selectStart()
     {
         $name = $this->adapter->quoteTableName($this->origin->getName());
-        $start = $this->adapter->fetchRow("SELECT MIN(id) FROM {$name}")[0];
+        $start = $this->adapter->fetchRow("SELECT MIN({$this->primaryKey}) FROM {$name}")[0];
 
         return (int)$start;
     }
@@ -114,7 +114,7 @@ class Chunker extends Command
     protected function selectLimit()
     {
         $name = $this->adapter->quoteTableName($this->origin->getName());
-        $limit = $this->adapter->fetchRow("SELECT MAX(id) FROM {$name}")[0];
+        $limit = $this->adapter->fetchRow("SELECT MAX({$this->primaryKey}) FROM {$name}")[0];
 
         return (int)$limit;
     }

--- a/tests/Integration/ChunkerTest.php
+++ b/tests/Integration/ChunkerTest.php
@@ -118,14 +118,14 @@ class ChunkerTest extends \PHPUnit_Framework_TestCase
                 switch ($matcher->getInvocationCount()) {
                     case 1:
                         $this->assertEquals(
-                            "SELECT MIN(id) FROM 'users'",
+                            "SELECT MIN(`id`) FROM 'users'",
                             $query
                         );
                         return [1];
 
                     case 2:
                         $this->assertEquals(
-                            "SELECT MAX(id) FROM 'users'",
+                            "SELECT MAX(`id`) FROM 'users'",
                             $query
                         );
                         return [500];


### PR DESCRIPTION
Ran into an issue with tables that did not use the column name `"id"` for their primary key.
