### PR TITLE
composer: relax psr/log version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
       "php": ">=5.5.0",
-      "psr/log": "1.0.0",
+      "psr/log": "^1.0.0",
       "symfony/console": "~2",
       "symfony/event-dispatcher": "~2",
       "symfony/monolog-bridge": "~2"


### PR DESCRIPTION
don't enforce artificial dependency

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package symfony/filesystem (installed at v2.8.19, required as ~2.7.0) is satisfiable by symfony/filesystem[v2.8.19] but these conflict with your requirements or minimum-stability.
  Problem 2 
    - Can only install one of: psr/log[1.0.2, 1.0.0]. 
    - Can only install one of: psr/log[1.0.0, 1.0.2].
    - masom/lhm 0.4.2 requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - Installation request for masom/lhm ^0.4.2 -> satisfiable by masom/lhm[0.4.2].
    - Installation request for psr/log (installed at 1.0.2) -> satisfiable by psr/log[1.0.2].
```