### PR TITLE
Refresh the project dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
-  - hhvm
-
-matrix:
-  allow_failures:
-    - php: 5.4
+  - 7.1
 
 install:
   - composer install
@@ -18,5 +11,5 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-  
+
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
       "psr-4": { "Lhm\\Tests\\": "tests/" }
     },
     "require": {
-      "php": ">=5.5.0",
+      "php": ">=7.0.0",
       "psr/log": "^1.0.0",
       "symfony/console": "~2",
       "symfony/event-dispatcher": "~2",
@@ -28,8 +28,8 @@
     },
     "require-dev": {
         "monolog/monolog": "~1.0",
-        "phpunit/phpunit": "4.6.4",
-        "robmorgan/phinx": "~0.4.0"
+        "phpunit/phpunit": "~6.1.0",
+        "robmorgan/phinx": "~0.8.0"
     },
     "suggest": {
         "robmorgan/phinx": "Advanced database migration tool",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+
+services:
+   db:
+     image: mysql:5.7
+     ports:
+       - "3306:3306"
+     environment:
+       MYSQL_ALLOW_EMPTY_PASSWORD: 1
+       MYSQL_DATABASE: lhm_php_test
+       MYSQL_USER: lhm_php
+       MYSQL_PASSWORD:

--- a/tests/Integration/AtomicSwitcherTest.php
+++ b/tests/Integration/AtomicSwitcherTest.php
@@ -1,14 +1,11 @@
 <?php
-
-
 namespace Lhm\Tests\Integration;
-
 
 use Lhm\AtomicSwitcher;
 use Phinx\Db\Adapter\AdapterInterface;
+use PHPUnit\Framework\TestCase;
 
-
-class AtomicSwitcherTest extends \PHPUnit_Framework_TestCase
+class AtomicSwitcherTest extends TestCase
 {
 
     /**

--- a/tests/Integration/ChunkerTest.php
+++ b/tests/Integration/ChunkerTest.php
@@ -1,16 +1,13 @@
 <?php
-
-
 namespace Lhm\Tests\Integration;
-
 
 use Lhm\Chunker;
 use Lhm\SqlHelper;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table\Column;
+use PHPUnit\Framework\TestCase;
 
-
-class ChunkerTest extends \PHPUnit_Framework_TestCase
+class ChunkerTest extends TestCase
 {
 
     /** @var Chunker */

--- a/tests/Integration/EntanglerTest.php
+++ b/tests/Integration/EntanglerTest.php
@@ -3,14 +3,13 @@
 
 namespace Lhm\Tests\Integration;
 
-
 use Lhm\Entangler;
 use Lhm\SqlHelper;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table\Column;
+use PHPUnit\Framework\TestCase;
 
-
-class EntanglerTest extends \PHPUnit_Framework_TestCase
+class EntanglerTest extends TestCase
 {
 
     /**

--- a/tests/Integration/LockedSwitcherTest.php
+++ b/tests/Integration/LockedSwitcherTest.php
@@ -1,13 +1,11 @@
 <?php
-
-
 namespace Lhm\Tests\Integration;
-
 
 use Lhm\LockedSwitcher;
 use Phinx\Db\Adapter\AdapterInterface;
+use PHPUnit\Framework\TestCase;
 
-class LockedSwitcherTest extends \PHPUnit_Framework_TestCase
+class LockedSwitcherTest extends TestCase
 {
 
     /**

--- a/tests/Integration/SqlHelperTest.php
+++ b/tests/Integration/SqlHelperTest.php
@@ -1,16 +1,13 @@
 <?php
-
-
 namespace Lhm\Tests\Integration;
-
 
 use Lhm\SqlHelper;
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Table;
 use Phinx\Db\Table\Column;
+use PHPUnit\Framework\TestCase;
 
-
-class SqlHelperTest extends \PHPUnit_Framework_TestCase
+class SqlHelperTest extends TestCase
 {
 
     /**

--- a/tests/Persistence/AbstractPersistenceTest.php
+++ b/tests/Persistence/AbstractPersistenceTest.php
@@ -1,14 +1,12 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence;
 
 use Phinx\Db\Adapter\AdapterInterface;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Symfony\Component\Console\Output\NullOutput;
+use PHPUnit\Framework\TestCase;
 
-
-abstract class AbstractPersistenceTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractPersistenceTest extends TestCase
 {
     /** @var AdapterInterface */
     protected $adapter;
@@ -25,7 +23,7 @@ abstract class AbstractPersistenceTest extends \PHPUnit_Framework_TestCase
             'port' => getenv('LHM_DATABASE_PORT') ?: 3306
         ];
 
-        $this->adapter = new MysqlAdapter($options, new NullOutput());
+        $this->adapter = new MysqlAdapter($options, null);
         $this->adapter->setOptions($options);
 
         // ensure the database is empty for each test

--- a/tests/Persistence/AtomicSwitcherTest.php
+++ b/tests/Persistence/AtomicSwitcherTest.php
@@ -1,8 +1,5 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence;
-
 
 use Lhm\AtomicSwitcher;
 use Lhm\Invoker;

--- a/tests/Persistence/LhmTest.php
+++ b/tests/Persistence/LhmTest.php
@@ -1,8 +1,5 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence;
-
 
 use Lhm\Lhm;
 use Lhm\Tests\Persistence\Migrations\HybridPhinxMigration;
@@ -13,7 +10,6 @@ use Phinx\Migration\Manager\Environment;
 use Phinx\Migration\MigrationInterface;
 use Lhm\Tests\Persistence\Migrations\IndexMigration;
 use Lhm\Tests\Persistence\Migrations\RenameMigration;
-
 
 class LhmTest extends AbstractPersistenceTest
 {
@@ -144,12 +140,7 @@ class LhmTest extends AbstractPersistenceTest
 
         $rows = $this->adapter->fetchAll(sprintf('SHOW INDEXES FROM %s', $this->adapter->quoteTableName('ponies')));
         foreach ($rows as $row) {
-            if ($row['Key_name'] === 'ponies_age_idx') {
-                if ($row['Column_name'] === 'age' && $row['Non_unique'] === '1') {
-                    $this->fail('The ponies_age_idx should have been removed.');
-                    break;
-                }
-            }
+            $this->assertFalse($row['Key_name'] === 'ponies_age_idx', 'The ponies_age_idx should have been removed.');
         }
     }
 

--- a/tests/Persistence/LockedSwitcherTest.php
+++ b/tests/Persistence/LockedSwitcherTest.php
@@ -1,8 +1,5 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence;
-
 
 use Lhm\LockedSwitcher;
 use Lhm\Invoker;

--- a/tests/Persistence/Migrations/HybridPhinxMigration.php
+++ b/tests/Persistence/Migrations/HybridPhinxMigration.php
@@ -1,12 +1,9 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence\Migrations;
 
 use Lhm\Lhm;
 use Phinx\Db\Table;
 use Phinx\Migration\AbstractMigration;
-
 
 class HybridPhinxMigration extends AbstractMigration
 {

--- a/tests/Persistence/Migrations/IndexMigration.php
+++ b/tests/Persistence/Migrations/IndexMigration.php
@@ -1,8 +1,5 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence\Migrations;
-
 
 use Lhm\Lhm;
 use Phinx\Db\Table;

--- a/tests/Persistence/Migrations/InitialMigration.php
+++ b/tests/Persistence/Migrations/InitialMigration.php
@@ -1,8 +1,5 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence\Migrations;
-
 
 use Phinx\Migration\AbstractMigration;
 

--- a/tests/Persistence/Migrations/LhmMigration.php
+++ b/tests/Persistence/Migrations/LhmMigration.php
@@ -1,6 +1,4 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence\Migrations;
 
 use Lhm\Lhm;

--- a/tests/Persistence/Migrations/RenameMigration.php
+++ b/tests/Persistence/Migrations/RenameMigration.php
@@ -1,12 +1,9 @@
 <?php
-
-
 namespace Lhm\Tests\Persistence\Migrations;
 
 use Lhm\Lhm;
 use Phinx\Db\Table;
 use Phinx\Migration\AbstractMigration;
-
 
 class RenameMigration extends AbstractMigration
 {

--- a/tests/Unit/IntersectionTest.php
+++ b/tests/Unit/IntersectionTest.php
@@ -1,13 +1,11 @@
 <?php
-
-
 namespace tests\Unit;
-
 
 use Lhm\Intersection;
 use Phinx\Db\Table\Column;
+use PHPUnit\Framework\TestCase;
 
-class IntersectionTest extends \PHPUnit_Framework_TestCase
+class IntersectionTest extends TestCase
 {
     /**
      * @var \Phinx\Db\Table

--- a/tests/Unit/SqlHelperTest.php
+++ b/tests/Unit/SqlHelperTest.php
@@ -1,11 +1,11 @@
 <?php
-
 namespace Lhm\Tests\Unit;
 
 use Lhm\SqlHelper;
 use Phinx\Db\Adapter\AdapterInterface;
+use PHPUnit\Framework\TestCase;
 
-class SqlHelperTest extends \PHPUnit_Framework_TestCase
+class SqlHelperTest extends TestCase
 {
     /**
      * @var SqlHelper


### PR DESCRIPTION
This tests lhm_php on Phinx 0.8.0 and PHP 7.

- Phinx dev dependency upgraded to 0.8.0
- Required PHP version bumped to 7.x
- PHPUnit upgraded to 6.1


This is a breaking change that will require a new minor release.