### PR TITLE
re-introduce php 5.6 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 5.6
   - 7.0
   - 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
       "psr-4": { "Lhm\\Tests\\": "tests/" }
     },
     "require": {
-      "php": ">=7.0.0",
+      "php": "^5.6.0 || ^7.0.0",
       "psr/log": "^1.0.0",
       "symfony/console": "~2",
       "symfony/event-dispatcher": "~2",
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "monolog/monolog": "~1.0",
-        "phpunit/phpunit": "~6.1.0",
+        "phpunit/phpunit": "^5.7.0 || ^6.1.0",
         "robmorgan/phinx": "~0.8.0"
     },
     "suggest": {


### PR DESCRIPTION
refs #12
more specifically https://github.com/masom/lhm_php/pull/12#issuecomment-300881603

looks like PHPUnit 5.7.19 works without the backward compat layer. so not adding it
https://travis-ci.org/masom/lhm_php/jobs/231292710